### PR TITLE
Fixing numpy 2 incompat with pyzed + Blueprint param error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rerun-sdk>=0.16.0
-numpy
+numpy<2.0
 scipy
 h5py
 opencv-python

--- a/src/raw.py
+++ b/src/raw.py
@@ -393,8 +393,7 @@ def blueprint_raw():
         ),
         BlueprintPanel(expanded=False),
         SelectionPanel(expanded=False),
-        TimePanel(expanded=False),
-        auto_space_views=False,
+        TimePanel(expanded=False)
     )
     return blueprint
 


### PR DESCRIPTION
This PR fixes 2 small issues:
- Numpy 2 binary incompatibility with older pyzed

```
Traceback (most recent call last):
  File "/root/droid-example/src/raw.py", line 421, in <module>
    main()
  File "/root/droid-example/src/raw.py", line 416, in main
    raw_scene = RawScene(args.scene)
  File "/root/droid-example/src/raw.py", line 153, in __init__
    self.cameras[camera_name] = StereoCamera(
  File "/root/droid-example/src/raw.py", line 29, in __init__
    import pyzed.sl as sl
  File "pyzed/sl.pyx", line 1, in init pyzed.sl
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

- Blueprint parameters error

```
Traceback (most recent call last):
  File "/root/droid-example/src/raw.py", line 421, in <module>
    main()
  File "/root/droid-example/src/raw.py", line 417, in main
    rr.send_blueprint(blueprint_raw())
  File "/root/droid-example/src/raw.py", line 333, in blueprint_raw
    blueprint = Blueprint(
TypeError: Blueprint.__init__() got an unexpected keyword argument 'auto_space_views'
```
